### PR TITLE
Fix content clipping when taller than viewport

### DIFF
--- a/countries/src/App.css
+++ b/countries/src/App.css
@@ -17,17 +17,24 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   font-size: calc(10px + 2vmin);
   overflow: auto;
 }
 
+.content > * {
+  margin-block: auto;
+  width: 100%;
+}
+
 .content--scroll {
-  justify-content: flex-start;
   align-items: stretch;
   padding: 20px 0 48px;
   background: linear-gradient(180deg, #03060f 0%, #101c2c 100%);
   background-attachment: fixed;
+}
+
+.content--scroll > * {
+  margin-block: 0;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
.content used justify-content: center + overflow: auto, which in flexbox pushes overflow above the scroll area — making the top of tall pages (e.g. /landskap showing the current prompt) inaccessible.

Replace with margin-block: auto on children: auto margins fill free space when content fits (still centered) and collapse to 0 when it overflows (scroll starts from the top). .content--scroll opts out so the Countries page keeps its existing top-aligned layout.